### PR TITLE
Update to latest plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
             <plugin>
                 <groupId>org.mvnsearch</groupId>
                 <artifactId>toolchains-maven-plugin</artifactId>
-                <version>4.0.0</version>
+                <version>4.3.0</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
The old version fails

```
[INFO] 
[INFO] --- toolchains:4.0.0:toolchain (default) @ java17-demo ---
[INFO] Required toolchain: jdk [ version='17' ]
[INFO] Begin to install JDK 17
[ERROR] Failed to download and install JDK
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
    at jdk.internal.util.Preconditions.outOfBounds (Preconditions.java:64)
    at jdk.internal.util.Preconditions.outOfBoundsCheckIndex (Preconditions.java:70)
    at jdk.internal.util.Preconditions.checkIndex (Preconditions.java:248)
    at java.util.Objects.checkIndex (Objects.java:372)
    at java.util.ArrayList.get (ArrayList.java:459)
    at com.google.gson.JsonArray.get (JsonArray.java:203)
    at org.apache.maven.plugins.toolchain.FoojayService.parseFileNameAndDownloadUrl (FoojayService.java:103)
    at org.apache.maven.plugins.toolchain.FoojayService.downloadAndExtractJdk (FoojayService.java:57)
    at org.apache.maven.plugins.toolchain.ToolchainMojo.autoInstallJdk (ToolchainMojo.java:213)
    at org.apache.maven.plugins.toolchain.ToolchainMojo.selectToolchain (ToolchainMojo.java:185)
    at org.apache.maven.plugins.toolchain.ToolchainMojo.execute (ToolchainMojo.java:108)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
...
```